### PR TITLE
Replace the writes to writter with write_all

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ impl<'a, T: Write, U: Read> Modem<'a, T, U> {
         #[cfg(feature = "defmt")]
         debug!("sending command: {=[u8]:a}", data);
 
-        self.writer.write(data).map_err(|_e| AtError::IOError)?;
+        self.writer.write_all(data).map_err(|_e| AtError::IOError)?;
 
         let mut read_buffer = [0; BUFFER_SIZE];
         let response_size = self.read_response(&mut read_buffer)?;
@@ -145,7 +145,7 @@ impl<'a, T: Write, U: Read> Modem<'a, T, U> {
 
         #[cfg(feature = "defmt")]
         debug!("sending command: {=[u8]:a}", data);
-        self.writer.write(data).map_err(|_e| AtError::IOError)?;
+        self.writer.write_all(data).map_err(|_e| AtError::IOError)?;
 
         let mut read_buffer = [0; BUFFER_SIZE];
         let response_size = self.read_response(&mut read_buffer)?;

--- a/src/nonblocking/mod.rs
+++ b/src/nonblocking/mod.rs
@@ -51,7 +51,7 @@ impl<'a, T: Write, U: Read> AsyncModem<T, U> {
         #[cfg(feature = "defmt")]
         debug!("payload: {=[u8]:a}", &data);
         self.writer
-            .write(data)
+            .write_all(data)
             .await
             .map_err(|_| AtError::IOError)?;
         let response_size = self.read_response(&mut buffer).await?;
@@ -74,7 +74,7 @@ impl<'a, T: Write, U: Read> AsyncModem<T, U> {
         let data = payload.get_command_no_error(&mut buffer);
         #[cfg(feature = "defmt")]
         debug!("payload: {=[u8]:a}", &data);
-        self.writer.write(data).await.unwrap();
+        self.writer.write_all(data).await.unwrap();
         match self.read_response(&mut buffer).await {
             Ok(response_size) => {
                 #[cfg(feature = "defmt")]


### PR DESCRIPTION
I have found an error that when the internal ring buffer to transmit to UART is full the programs get stuck.

The sequence is the following:

- Have a buffer of size N.
- Fill the buffer until (N-3) (3 is an example here)
- Write a command of length 10.
- Only 3 bytes are written to the UART TX
- The program will await for the next SIM module response, but there will not be an answer because the last command was not fully sent.

To fix this I replaced the usages of write with write_all, which will ensure that all the bytes are written.

I don't know if this is an embedded-io/embassy error or is an intended behaviour, but this will be a workaround for the problem.