### PR TITLE
Add the derive for defmt, Clone and PartialEq

### DIFF
--- a/src/at_command/at.rs
+++ b/src/at_command/at.rs
@@ -6,8 +6,8 @@ use crate::AtError;
 use defmt::{error, info};
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy)]
-pub struct At {}
+#[derive(PartialEq, Clone)]
+pub struct At;
 
 impl At {
     fn get_command_response(data: &[u8]) -> Result<(&str, &str), AtError> {

--- a/src/at_command/at_cgatt.rs
+++ b/src/at_command/at_cgatt.rs
@@ -5,14 +5,18 @@ use crate::AtError;
 use at_commands::parser::CommandParser;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum GPRSServiceState {
     Detached, // 0
     Attached, // 1
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct GPRSServiceStatus;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct PacketDomainAttachmentState {
     pub state: GPRSServiceState,
 }

--- a/src/at_command/at_cpin.rs
+++ b/src/at_command/at_cpin.rs
@@ -4,12 +4,13 @@ use crate::at_command::{AtRequest, BufferType};
 use crate::AtError;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 /// Test if a pin is required.
 pub struct PINRequired;
 
 /// Indicates the response of [PinRequired]
-#[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone, Debug)]
 pub enum PinStatus {
     Ready,
     SimPin,
@@ -112,6 +113,7 @@ impl AtRequest for PINRequired {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 /// Enter PIN.
 pub struct EnterPIN {
     pub pin: u16,

--- a/src/at_command/at_creg.rs
+++ b/src/at_command/at_creg.rs
@@ -7,8 +7,11 @@ use crate::at_command::{AtRequest, BufferType};
 use crate::AtError;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct NetworkRegistration;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct NetworkRegistrationResponse {
     pub unsolicited_result: UnsolicitedResultCodes,
     pub status: NetworkRegistrationStatus,
@@ -58,6 +61,7 @@ impl AtRequest for NetworkRegistration {
 
 // provokes an error for testing purposes
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct AtCregError;
 
 impl AtRequest for AtCregError {

--- a/src/at_command/at_csq.rs
+++ b/src/at_command/at_csq.rs
@@ -4,8 +4,11 @@ use crate::at_command::{AtRequest, BufferType};
 use crate::AtError;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct SignalQualityReport;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct SignalQualityResponse {
     pub rx_signal_strength: i32,
     pub rx_quality: i32,

--- a/src/at_command/at_cstt.rs
+++ b/src/at_command/at_cstt.rs
@@ -4,8 +4,9 @@ use crate::AtError;
 const CSTT_SIZE_MAX: usize = 32; // AT Datasheet page 172
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 /// Enter PIN.
-pub struct GetAPNUserPassword {}
+pub struct GetAPNUserPassword;
 
 impl AtRequest for GetAPNUserPassword {
     type Response = ();
@@ -22,6 +23,7 @@ impl AtRequest for GetAPNUserPassword {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 /// Enter PIN.
 pub struct SetAPNUserPassword {
     pub(crate) apn: Option<[u8; CSTT_SIZE_MAX]>,

--- a/src/at_command/at_psd.rs
+++ b/src/at_command/at_psd.rs
@@ -1,5 +1,7 @@
 use crate::at_command::AtRequest;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum PdpType {
     IP,
     IPV6,
@@ -18,6 +20,8 @@ impl PdpType {
     }
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct SetPSDSettings<'a> {
     pdp_type: PdpType,
     apn: Option<&'a str>,

--- a/src/at_command/ate.rs
+++ b/src/at_command/ate.rs
@@ -2,7 +2,7 @@ use crate::at_command::{AtRequest, BufferType};
 use crate::AtError;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy)]
+#[derive(PartialEq, Clone)]
 #[repr(u8)]
 pub enum EchoState {
     Disabled,
@@ -10,7 +10,7 @@ pub enum EchoState {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy)]
+#[derive(PartialEq, Clone)]
 #[repr(u8)]
 pub enum Echo {
     Disable = 0,
@@ -18,8 +18,8 @@ pub enum Echo {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy)]
-pub struct AtEchoState {}
+#[derive(PartialEq, Clone)]
+pub struct AtEchoState;
 
 impl AtRequest for AtEchoState {
     type Response = ();
@@ -35,7 +35,7 @@ impl AtRequest for AtEchoState {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy)]
+#[derive(PartialEq, Clone)]
 pub struct AtEcho {
     pub status: Echo,
 }

--- a/src/at_command/ati.rs
+++ b/src/at_command/ati.rs
@@ -1,9 +1,10 @@
 use crate::at_command::{AtRequest, BufferType};
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct AtI;
 
-pub struct ProductInformation {}
+pub struct ProductInformation;
 
 impl AtRequest for AtI {
     type Response = ProductInformation;

--- a/src/at_command/battery.rs
+++ b/src/at_command/battery.rs
@@ -6,12 +6,14 @@ use at_commands::parser::CommandParser;
 
 #[allow(dead_code)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct BatteryChargeStatus {
     capacity_percent: i32,
     voltage_millivolt: i32,
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct BatteryCharge;
 
 impl BatteryCharge {

--- a/src/at_command/ceer.rs
+++ b/src/at_command/ceer.rs
@@ -7,6 +7,7 @@ use crate::AtError;
 use defmt::info;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct ExtendedErrorReport;
 
 impl AtRequest for ExtendedErrorReport {

--- a/src/at_command/cgcontrdp.rs
+++ b/src/at_command/cgcontrdp.rs
@@ -7,6 +7,7 @@ use crate::AtError;
 use defmt::warn;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct PDPContextReadDynamicsParameters;
 
 const APN_MAX_SIZE: usize = 255;
@@ -14,6 +15,8 @@ const LOCAL_ADDRESS_AND_SUBNET_MASK_MAX_SIZE: usize = 255;
 const GATEWAY_ADDRESS_MAX_SIZE: usize = 255;
 const DNS_MAX_SIZE: usize = 128;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct PDPContextReadDynamicsParametersResponse {
     pub cid: i32,
     pub bearer_id: i32,

--- a/src/at_command/clock.rs
+++ b/src/at_command/clock.rs
@@ -5,7 +5,8 @@ use crate::AtError;
 use chrono::NaiveDateTime;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Clock {}
+#[derive(PartialEq, Clone)]
+pub struct Clock;
 
 impl Clock {
     fn parse_clock_response(data: &[u8]) -> Result<NaiveDateTime, AtError> {

--- a/src/at_command/cmee.rs
+++ b/src/at_command/cmee.rs
@@ -7,6 +7,7 @@ use crate::AtError;
 use defmt::info;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct ReportMobileEquipmentError;
 
 impl ReportMobileEquipmentError {
@@ -54,6 +55,7 @@ impl AtRequest for ReportMobileEquipmentError {
 
 #[repr(u8)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum ReportMobileEquipmentErrorSetting {
     Disabled = 0,
     Numeric = 1,
@@ -82,6 +84,7 @@ impl From<i32> for ReportMobileEquipmentErrorSetting {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct SetReportMobileEquipmentError {
     pub setting: ReportMobileEquipmentErrorSetting,
 }

--- a/src/at_command/flow_control.rs
+++ b/src/at_command/flow_control.rs
@@ -8,6 +8,7 @@ use at_commands::parser::CommandParser;
 use defmt::info;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum ControlFlowStatus {
     No,
     Software,
@@ -15,6 +16,7 @@ pub enum ControlFlowStatus {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct SetFlowControl {
     pub(crate) ta_to_te: ControlFlowStatus,
     pub(crate) te_to_ta: ControlFlowStatus,
@@ -69,9 +71,12 @@ impl AtRequest for SetFlowControl {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct GetFlowControl;
 
 #[allow(unused)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct GetFlowControlResponse {
     pub dce_by_dte: ControlFlowStatus,
     pub dte_by_dce: ControlFlowStatus,

--- a/src/at_command/http.rs
+++ b/src/at_command/http.rs
@@ -9,11 +9,13 @@ use at_commands::parser::CommandParser;
 use defmt::*;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct HttpClient {
     pub client_id: u8,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct HttpSession<'a> {
     pub client_id: u8,
     pub successful: bool,
@@ -24,22 +26,24 @@ const HTTP_SESSION_SUCCESSFULLY: i32 = 1;
 const HTTP_SESSION_FAILED: i32 = 0;
 const DEFAULT_N_SESSIONS: usize = 4;
 
-/// create a HTTP or HTTPS session
+/// create an HTTP or HTTPS session
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GetHttpSessions<
     const N_SESSIONS: usize = DEFAULT_N_SESSIONS,
     const HOST_MAX_SIZE: usize = DEFAULT_HOST_MAX_SIZE,
 > {}
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum HttpSessionState {
-    Sucessfully,
+    Successfully,
     Failed,
 }
 
 impl From<i32> for HttpSessionState {
     fn from(value: i32) -> Self {
         match value {
-            HTTP_SESSION_SUCCESSFULLY => HttpSessionState::Sucessfully,
+            HTTP_SESSION_SUCCESSFULLY => HttpSessionState::Successfully,
             HTTP_SESSION_FAILED => HttpSessionState::Failed,
             _ => core::unreachable!(),
         }
@@ -48,6 +52,8 @@ impl From<i32> for HttpSessionState {
 
 const DEFAULT_HOST_MAX_SIZE: usize = 255;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct HttpSessionInformation<const HOST_MAX_SIZE: usize = DEFAULT_HOST_MAX_SIZE> {
     pub http_client_id: i32,
     pub state: HttpSessionState,
@@ -157,12 +163,15 @@ impl<const HOST_MAX_SIZE: usize> AtRequest for GetHttpSessions<DEFAULT_N_SESSION
 
 /// create a HTTP or HTTPS session
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct CreateHttpSession<'a> {
     pub host: &'a str,
     pub user: Option<&'a str>,
     pub password: Option<&'a str>,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct CreateHttpSessionResponse {
     pub client_id: u8,
 }
@@ -206,6 +215,7 @@ impl AtRequest for CreateHttpSession<'_> {
 
 /// Connect to a server using http or https
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct HttpConnect {
     pub client_id: u8,
 }
@@ -227,6 +237,7 @@ impl AtRequest for HttpConnect {
 
 /// Disconnect from a server
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct HttpDisconnect {
     pub client_id: u8,
 }
@@ -248,6 +259,7 @@ impl AtRequest for HttpDisconnect {
 
 /// Connect to a server using http or https
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct HttpDestroy {
     pub client_id: u8,
 }
@@ -268,6 +280,7 @@ impl AtRequest for HttpDestroy {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 #[repr(u8)]
 pub enum HttpMethod {
     GET = 0,
@@ -280,6 +293,7 @@ pub enum HttpMethod {
 /// content_type: A string indicate the content type of the content, if the method is not POST and PUT, it must be empty.
 /// content_string: The string converted from content hex data.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct HttpSend<'a> {
     pub client_id: u8,
     pub method: HttpMethod,

--- a/src/at_command/ip_address.rs
+++ b/src/at_command/ip_address.rs
@@ -7,10 +7,13 @@ use at_commands::parser::CommandParser;
 use defmt::info;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct LocalIPAddress;
 
 const MAX_IP_SIZE: usize = 39;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct LocalIpAddressResponse {
     pub ip: heapless::String<MAX_IP_SIZE>,
 }

--- a/src/at_command/model_identification.rs
+++ b/src/at_command/model_identification.rs
@@ -6,10 +6,13 @@ use crate::AtError;
 use defmt::error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ModelIdentification {}
+#[derive(PartialEq, Clone)]
+pub struct ModelIdentification;
 
 pub const MODEL_IDENTIFIER_SIZE: usize = 8;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct ModelIdentificationResponse {
     pub model: [u8; MODEL_IDENTIFIER_SIZE],
 }

--- a/src/at_command/mqtt.rs
+++ b/src/at_command/mqtt.rs
@@ -10,13 +10,16 @@ use embedded_io::{Read, Write};
 
 const MAX_SERVER_LEN: usize = 50;
 
-#[cfg_attr(feature = "defmt", derive(defmt::Format, Debug))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum MQTTError {
     ConnectionFailed,
     Disconnected,
     Publish,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct Mqtt<'a> {
     session_settings: &'a MQTTSessionSettings<'a>,
     session_wrapper: MQTTSessionWrapper,
@@ -93,6 +96,8 @@ impl<'a> Mqtt<'a> {
     }
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 enum MQTTSessionWrapper {
     Disconnected(MQTTSession<StateDisconnected>),
     Connected(MQTTSession<StateConnected>),
@@ -163,16 +168,24 @@ impl MQTTSessionWrapper {
     }
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct MQTTSession<S> {
     state: S,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 struct StateDisconnected {}
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 struct StateConnected {
     mqtt_id: u8,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 struct StateConnectedGood {
     mqtt_id: u8,
 }
@@ -264,6 +277,7 @@ impl MQTTSession<StateConnectedGood> {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum MQTTConnection {
     Connected(u8),
     Disconnected,
@@ -295,6 +309,7 @@ impl MQTTConnection {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 /// Create a new MQTT connection
 pub struct MQTTSessionSettings<'a> {
     pub server: &'a str,
@@ -336,6 +351,8 @@ impl MQTTSessionSettings<'_> {
     }
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct MqttSessionId {
     pub mqtt_id: u8,
 }
@@ -378,7 +395,8 @@ impl AtRequest for MQTTSessionSettings<'_> {
     }
 }
 
-#[cfg_attr(feature = "defmt", derive(defmt::Format, Debug))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum UsedState {
     NotUsed,
     Used,
@@ -394,8 +412,12 @@ impl From<i32> for UsedState {
     }
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct GetMQTTSession {}
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct GetMQTTSessionResponse {
     pub mqtt_id: u8,
     pub used_state: UsedState,
@@ -451,6 +473,7 @@ impl AtRequest for GetMQTTSession {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct CloseMQTTConnection {
     pub mqtt_id: u8,
 }
@@ -471,12 +494,15 @@ impl AtRequest for CloseMQTTConnection {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 #[repr(u8)]
 pub enum MQTTVersion {
     MQTT31,
     MQTT311,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct WillOptions<'a> {
     pub topic: &'a str,
     pub quality_of_service: u8,
@@ -484,6 +510,7 @@ pub struct WillOptions<'a> {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 struct MQTTConnectionSettingsWithID<'a> {
     mqtt_id: u8,
     version: MQTTVersion,
@@ -497,6 +524,7 @@ struct MQTTConnectionSettingsWithID<'a> {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct MQTTConnectionSettings<'a> {
     pub version: MQTTVersion,
     pub client_id: &'a str,
@@ -550,12 +578,14 @@ impl AtRequest for MQTTConnectionSettingsWithID<'_> {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum MQTTDataFormat {
     Bytes,
     Hex,
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct MQTTRawData {
     pub data_format: MQTTDataFormat,
 }
@@ -584,6 +614,7 @@ impl AtRequest for MQTTRawData {
 ///
 /// The message length has to be between 2 and 1000 byte.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct MQTTMessage<'a> {
     pub topic: &'a str,    // length max 128b
     pub qos: u8,           // 0 | 1 | 2
@@ -596,6 +627,7 @@ pub struct MQTTMessage<'a> {
 ///
 /// The message length has to be between 2 and 1000 byte.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct MQTTPublish<'a> {
     pub mqtt_id: u8,       // AT+CMQNEW response
     pub topic: &'a str,    // length max 128b
@@ -627,6 +659,7 @@ impl AtRequest for MQTTPublish<'_> {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct MQTTSubscribe<'a> {
     pub mqtt_id: u8,    // AT+CMQNEW response
     pub topic: &'a str, // length max 128b

--- a/src/at_command/network_information.rs
+++ b/src/at_command/network_information.rs
@@ -5,6 +5,7 @@ use crate::AtError;
 use at_commands::parser::CommandParser;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum NetworkFormat {
     LongAlphanumeric,
     ShortAlphanumeric,
@@ -24,7 +25,7 @@ impl From<i32> for NetworkFormat {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Clone)]
 pub enum NetworkMode {
     Automatic,
     Manual,
@@ -44,12 +45,16 @@ impl From<i32> for NetworkMode {
 /// the network. Any of the formats may be unavailable and should then be an
 /// empty field. The list of operators shall be in order: home network,
 /// networks referenced in SIM, and other networks.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct NetworkInformation;
 
 const OPERATOR_MAX_SIZE: usize = 16;
 
 pub type NetworkOperator = heapless::String<OPERATOR_MAX_SIZE>;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct NetworkInformationState {
     pub mode: NetworkMode,
     pub format: NetworkFormat,

--- a/src/at_command/network_registration_status.rs
+++ b/src/at_command/network_registration_status.rs
@@ -4,6 +4,7 @@ use crate::at_command::{AtRequest, BufferType};
 use crate::AtError;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum UnsolicitedResultCodes {
     Disabled,
     Enabled,
@@ -24,6 +25,7 @@ impl From<i32> for UnsolicitedResultCodes {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum NetworkRegistrationStatus {
     NotRegistered,
     RegisteredHomeNetwork,
@@ -54,8 +56,11 @@ impl From<i32> for NetworkRegistrationStatus {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct NetworkRegistration;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct NetworkRegistrationResponse {
     pub unsolicited: UnsolicitedResultCodes,
     pub status: NetworkRegistrationStatus,

--- a/src/at_command/ntp.rs
+++ b/src/at_command/ntp.rs
@@ -2,6 +2,7 @@ use crate::at_command::{AtRequest, BufferType};
 use crate::AtError;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct StartQueryNTP<'a> {
     pub url: &'a str,
     pub tzinfo: Option<&'a str>, // currently not implemented
@@ -30,6 +31,7 @@ impl AtRequest for StartQueryNTP<'_> {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct StopQueryNTP;
 
 impl AtRequest for StopQueryNTP {

--- a/src/at_command/pdp_context.rs
+++ b/src/at_command/pdp_context.rs
@@ -7,6 +7,7 @@ use at_commands::parser::CommandParser;
 use defmt::debug;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum PDPState {
     Deactivated,
     Activated,
@@ -25,6 +26,7 @@ impl From<i32> for PDPState {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct PDPContext;
 
 pub struct PDPContextResponse {

--- a/src/at_command/power_saving_mode.rs
+++ b/src/at_command/power_saving_mode.rs
@@ -5,6 +5,7 @@ use crate::AtError;
 use at_commands::parser::CommandParser;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum PowerSavingModeState {
     Disabled,
     Enabled,
@@ -25,6 +26,7 @@ impl From<i32> for PowerSavingModeState {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct GetPowerSavingMode;
 
 impl GetPowerSavingMode {
@@ -62,6 +64,7 @@ impl AtRequest for GetPowerSavingMode {
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct SetPowerSavingMode;
 
 impl SetPowerSavingMode {

--- a/src/at_command/sleep_indication.rs
+++ b/src/at_command/sleep_indication.rs
@@ -5,6 +5,7 @@ use crate::AtError;
 use at_commands::parser::CommandParser;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub enum SleepIndication {
     Disabled,
     Enabled,
@@ -22,6 +23,8 @@ impl From<i32> for SleepIndication {
     }
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct SleepIndicationStatus;
 
 impl SleepIndicationStatus {

--- a/src/at_command/socket.rs
+++ b/src/at_command/socket.rs
@@ -7,7 +7,8 @@ use crate::{
 
 /// Domain for the socket connection
 #[repr(u8)]
-#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Domain {
     IPv4 = 1,
     IPv6 = 2,
@@ -15,7 +16,8 @@ pub enum Domain {
 
 /// Indicates the type of connection for the socket
 #[repr(u8)]
-#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Type {
     TCP = 1,
     UPD = 2,
@@ -24,7 +26,8 @@ pub enum Type {
 
 /// Indicates the underlaying protocol using for the socket
 #[repr(u8)]
-#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Protocol {
     IP = 1,
     ICMP = 2,
@@ -32,6 +35,8 @@ pub enum Protocol {
 }
 
 /// AT command to create a socket
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct CreateSocket {
     /// Type of IP connection that will be used
     pub domain: Domain,
@@ -43,6 +48,8 @@ pub struct CreateSocket {
     pub cid: Option<i32>,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq)]
 pub struct SocketCreated {
     pub socket_id: u8,
 }
@@ -91,6 +98,8 @@ impl AtRequest for CreateSocket {
 }
 
 /// Command to connect the socket to a remote address
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct ConnectSocketToRemote<'a> {
     /// Socket ID obtained by using [CreateSocket]
     pub socket_id: u8,
@@ -130,6 +139,8 @@ impl AtRequest for ConnectSocketToRemote<'_> {
 }
 
 /// Struct used to send data through the socket
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq)]
 pub struct SendSocketMessage<'a> {
     /// Socket ID obtained by using [CreateSocket]
     pub socket_id: u8,
@@ -167,6 +178,8 @@ impl AtRequest for SendSocketMessage<'_> {
 }
 
 /// Closes the opened TCP socket
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct CloseSocket {
     /// Socket ID obtained by using [CreateSocket]
     pub socket_id: u8,

--- a/src/at_command/wireless.rs
+++ b/src/at_command/wireless.rs
@@ -1,6 +1,7 @@
 use crate::at_command::{AtRequest, BufferType};
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(PartialEq, Clone)]
 pub struct StartWirelessConnection;
 
 impl AtRequest for StartWirelessConnection {


### PR DESCRIPTION
I have added to all the commands structs and enums the Derive for PartialEq, Clone and defmt and those could be useful to the user of the library because they are not able to implement them